### PR TITLE
Add CI workflow and fix builds for wine-10.20 + vkd3d-1.19

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -317,6 +317,8 @@ jobs:
     steps:
     - name: Checkout wined3d_vs
       uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
 
     - name: Download all artifacts
       uses: actions/download-artifact@v4
@@ -335,11 +337,28 @@ jobs:
         done
         ls -la *.zip
 
+    - name: Determine release tag
+      id: tag
+      run: |
+        if [ -n "${{ inputs.release_tag }}" ]; then
+          echo "tag=${{ inputs.release_tag }}" >> "$GITHUB_OUTPUT"
+          echo "name=${{ inputs.release_tag }}" >> "$GITHUB_OUTPUT"
+        else
+          echo "tag=build-${{ github.run_number }}" >> "$GITHUB_OUTPUT"
+          echo "name=Build #${{ github.run_number }}" >> "$GITHUB_OUTPUT"
+        fi
+
+    - name: Create git tag
+      run: git tag ${{ steps.tag.outputs.tag }}
+
+    - name: Push tag
+      run: git push origin ${{ steps.tag.outputs.tag }}
+
     - name: Create GitHub Release
       uses: softprops/action-gh-release@v2
       with:
-        tag_name: "${{ inputs.release_tag || format('build-{0}', github.run_number) }}"
-        name: "${{ inputs.release_tag || format('Build #{0}', github.run_number) }}"
+        tag_name: ${{ steps.tag.outputs.tag }}
+        name: ${{ steps.tag.outputs.name }}
         body: "Wine D3D DLLs built from ${{ env.WINE_TAG }} with vkd3d ${{ env.VKD3D_TAG }} (Vulkan/d3d12 support). Includes: d3d8, d3d9, d3d11, d3d12, ddraw, dxgi, d3d10core, d2d1, d3dx9_36, d3dxof, d3drm, dsound, wined3d, vkd3d, debug symbols (PDBs)"
         files: artifacts/*.zip
       env:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,6 +31,10 @@ jobs:
             platform: Win32
           - configuration: Release
             platform: Win32
+          - configuration: Debug
+            platform: x64
+          - configuration: Release
+            platform: x64
 
     steps:
     - name: Checkout wined3d_vs

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,296 @@
+name: Build
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+  workflow_dispatch:
+    inputs:
+      create_release:
+        description: 'Create GitHub Release'
+        required: false
+        default: false
+        type: boolean
+      release_tag:
+        description: 'Release tag (e.g. wine-10.0-rc4)'
+        required: false
+        type: string
+
+env:
+  WINE_TAG: wine-10.20
+  VKD3D_TAG: vkd3d-1.19
+
+jobs:
+  build:
+    runs-on: windows-2025-vs2026
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - configuration: Debug
+            platform: Win32
+          - configuration: Release
+            platform: Win32
+
+    steps:
+    - name: Checkout wined3d_vs
+      uses: actions/checkout@v4
+      with:
+        path: wined3d_vs
+
+    - name: Clone Wine sources
+      run: git clone --depth 1 --branch $env:WINE_TAG https://github.com/wine-mirror/wine.git wine
+
+    - name: Clone vkd3d sources
+      run: git clone --depth 1 --branch $env:VKD3D_TAG https://gitlab.winehq.org/wine/vkd3d.git vkd3d
+
+    - name: Apply patches to Wine
+      shell: pwsh
+      working-directory: wined3d_vs
+      run: |
+        Get-ChildItem -Path "patches" -Filter "*.patch" | Sort-Object Name | ForEach-Object {
+          Write-Host "Applying $($_.Name)..."
+          git -C "$env:GITHUB_WORKSPACE\wine" apply --ignore-whitespace $_.FullName
+        }
+
+    - name: Generate vkd3d spirv_grammar.h
+      shell: pwsh
+      run: |
+        $grammar = "$env:GITHUB_WORKSPACE\vkd3d\include\private\spirv.core.grammar.json"
+        $output = "$env:GITHUB_WORKSPACE\vkd3d\include\private\spirv_grammar.h"
+        $makeSpirv = "$env:GITHUB_WORKSPACE\vkd3d\libs\vkd3d-shader\make_spirv"
+        if (Test-Path $grammar) {
+          perl $makeSpirv $grammar | Set-Content $output -Encoding utf8
+          Write-Host "Generated spirv_grammar.h"
+        } else {
+          Write-Host "No spirv grammar JSON found, skipping generation"
+        }
+
+    - name: Patch vkd3d for MSVC compatibility
+      shell: pwsh
+      run: |
+        $file = "$env:GITHUB_WORKSPACE\vkd3d\libs\vkd3d\vkd3d_private.h"
+        $content = Get-Content $file -Raw
+        $content = $content.Replace(
+          'uint8_t DECLSPEC_ALIGN(sizeof(void *)) descriptors[]',
+          @"
+        uint8_t
+        #ifdef _WIN64
+            DECLSPEC_ALIGN(8)
+        #else
+            DECLSPEC_ALIGN(4)
+        #endif
+            descriptors[]
+        "@
+        )
+        Set-Content $file $content -NoNewline
+        Write-Host "Patched vkd3d_private.h for MSVC"
+
+        # Patch vkd3d_utils.h to remove __declspec(dllimport) from function
+        # declarations that conflict with Wine's IDL-generated headers
+        $utilsFile = "$env:GITHUB_WORKSPACE\vkd3d\include\vkd3d_utils.h"
+        $utils = Get-Content $utilsFile -Raw
+        $utils = $utils -replace 'VKD3D_UTILS_API (HRESULT WINAPI )', '$1'
+        $utils = $utils -replace 'VKD3D_UTILS_API (HANDLE )', '$1'
+        $utils = $utils -replace 'VKD3D_UTILS_API (HRESULT )', '$1'
+        $utils = $utils -replace 'VKD3D_UTILS_API (unsigned int )', '$1'
+        $utils = $utils -replace 'VKD3D_UTILS_API (void )', '$1'
+        Set-Content $utilsFile $utils -NoNewline
+        Write-Host "Patched vkd3d_utils.h to remove dllimport from declarations"
+
+        # Also strip VKD3D_UTILS_API from the .c file to avoid linkage conflict
+        # with WIDL-generated vkd3d_d3d12.h which declares D3D12CreateDevice
+        # without __declspec(dllexport)
+        $utilsCFile = "$env:GITHUB_WORKSPACE\vkd3d\libs\vkd3d-utils\vkd3d_utils_main.c"
+        $utilsC = Get-Content $utilsCFile -Raw
+        $utilsC = $utilsC -replace 'VKD3D_UTILS_API ', ''
+        Set-Content $utilsCFile $utilsC -NoNewline
+        Write-Host "Patched vkd3d_utils_main.c to remove VKD3D_UTILS_API"
+
+    - name: Fetch missing wine headers from master
+      shell: pwsh
+      run: |
+        # wtypesbase.idl was added to wine after 10.4 release
+        $url = "https://raw.githubusercontent.com/wine-mirror/wine/master/include/wtypesbase.idl"
+        $out = "$env:GITHUB_WORKSPACE\wine\include\wtypesbase.idl"
+        Invoke-WebRequest -Uri $url -OutFile $out
+        Write-Host "Downloaded wtypesbase.idl"
+
+    - name: Install Vulkan SDK
+      uses: humbletim/setup-vulkan-sdk@v1.2.1
+      with:
+        vulkan-query-version: 1.3.280.0
+        vulkan-components: Vulkan-Headers, SPIRV-Headers
+
+    - name: Setup MSBuild
+      uses: microsoft/setup-msbuild@v2
+
+    - name: Exclude Windows SDK headers
+      shell: pwsh
+      run: |
+        # Find UCRT (standard C headers: assert.h, stdio.h, etc.)
+        $sdkInclude = "${env:ProgramFiles(x86)}\Windows Kits\10\Include"
+        if (-not (Test-Path $sdkInclude)) { $sdkInclude = "$env:ProgramFiles\Windows Kits\10\Include" }
+        $latestSdk = Get-ChildItem $sdkInclude -Directory | Sort-Object Name -Descending | Select-Object -First 1
+        $ucrtPath = Join-Path $latestSdk.FullName "ucrt"
+        Write-Host "UCRT: $ucrtPath"
+        # Find VC include (compiler intrinsics: stddef.h, etc.)
+        $vcBase = "${env:ProgramFiles}\Microsoft Visual Studio"
+        $vcPath = Get-ChildItem "$vcBase\*\*\VC\Tools\MSVC\*" -Directory -ErrorAction SilentlyContinue |
+          Sort-Object Name -Descending | Select-Object -First 1
+        if ($vcPath) { $vcPath = Join-Path $vcPath.FullName "include" }
+        Write-Host "VC: $vcPath"
+        # Set INCLUDE to UCRT+VC only (no Windows SDK um/shared to avoid rpc.h conflicts)
+        $env:INCLUDE = "$ucrtPath;$vcPath"
+        "INCLUDE=$ucrtPath;$vcPath" | Out-File -Append -Encoding utf8 $env:GITHUB_ENV
+        # Strip $(IncludePath) from all vcxproj files so MSBuild won't add SDK paths via /I flags
+        Get-ChildItem "$env:GITHUB_WORKSPACE\wined3d_vs" -Recurse -Filter "*.vcxproj" | ForEach-Object {
+          $content = Get-Content $_.FullName -Raw
+          if ($content.Contains('$(IncludePath)')) {
+            $content = $content.Replace(';$(IncludePath)', '')
+            Set-Content $_.FullName $content -NoNewline
+            Write-Host "Stripped `$(IncludePath) from $($_.Name)"
+          }
+        }
+
+    - name: Build foundational projects
+      shell: pwsh
+      working-directory: wined3d_vs
+      run: |
+        $cfg = "/p:Configuration=${{ matrix.configuration }}"
+        $plat = "/p:Platform=${{ matrix.platform }}"
+        $sln = "/p:SolutionDir=$PWD\"
+        # Build order: idls → winecrt0, dxguid, winebuild → everything else
+        $foundation = @(
+          "make_xftmpl\make_xftmpl.vcxproj",
+          "idls\idls.vcxproj",
+          "winecrt0\winecrt0.vcxproj",
+          "dxguid\dxguid.vcxproj",
+          "winebuild\winebuild.vcxproj"
+        )
+        foreach ($proj in $foundation) {
+          Write-Host "=== Building $proj ==="
+          & msbuild $proj $cfg $plat $sln /verbosity:minimal
+          if ($LASTEXITCODE -ne 0) { exit 1 }
+        }
+
+    - name: Build vkd3d libraries
+      shell: pwsh
+      working-directory: wined3d_vs
+      run: |
+        $msbuildArgs = @(
+          "/p:Configuration=${{ matrix.configuration }}",
+          "/p:Platform=${{ matrix.platform }}",
+          "/p:SolutionDir=$PWD\",
+          "/m",
+          "/verbosity:minimal"
+        )
+        $projects = @(
+          "vkd3d-idls\vkd3d-idls.vcxproj",
+          "vkd3d-common\vkd3d-common.vcxproj",
+          "vkd3d-shader\vkd3d-shader.vcxproj",
+          "vkd3d\vkd3d.vcxproj",
+          "vkd3d-utils\vkd3d-utils.vcxproj"
+        )
+        foreach ($proj in $projects) {
+          Write-Host "=== Building $proj ==="
+          & msbuild $proj @msbuildArgs
+          if ($LASTEXITCODE -ne 0) {
+            Write-Error "FAILED: $proj"
+            exit 1
+          }
+        }
+
+    - name: Build core solution
+      run: >
+        msbuild wined3d.sln
+        /p:Configuration=${{ matrix.configuration }}
+        /p:Platform=${{ matrix.platform }}
+        /verbosity:minimal
+      working-directory: wined3d_vs
+      continue-on-error: true
+
+    - name: Package DLLs
+      shell: pwsh
+      run: |
+        $wineVersion = $env:WINE_TAG -replace '^wine-', ''
+        Write-Host "Wine version: $wineVersion"
+
+        $platform = "${{ matrix.platform }}"
+        $config = "${{ matrix.configuration }}"
+        $privateDir = "$env:GITHUB_WORKSPACE\wined3d_vs\${platform}_${config}"
+        $frontendDir = "$env:GITHUB_WORKSPACE\wined3d_vs\${platform}_${config}_dll"
+
+        $pkgDir = "$env:GITHUB_WORKSPACE\package\$wineVersion"
+        New-Item -ItemType Directory -Path $pkgDir -Force | Out-Null
+
+        $timestamp = Get-Date -Format "yyyy-MM-dd HH:mm:ss"
+        $commit = git -C "$env:GITHUB_WORKSPACE\wined3d_vs" rev-parse --short HEAD
+        Set-Content -Path "$pkgDir\build-timestamp" -Value "$timestamp`ncommit: $commit" -Encoding utf8
+
+        $dllCount = 0
+        foreach ($dir in @($privateDir, $frontendDir)) {
+          if (Test-Path $dir) {
+            Get-ChildItem -Path $dir -Filter "*.dll" | ForEach-Object {
+              Write-Host "  $($_.Name)"
+              Copy-Item $_.FullName -Destination $pkgDir
+              $dllCount++
+            }
+          }
+        }
+        Write-Host "`nPackaged $dllCount DLLs -> $pkgDir"
+
+        $pdbDir = "$env:GITHUB_WORKSPACE\package\${wineVersion}_pdbs"
+        New-Item -ItemType Directory -Path $pdbDir -Force | Out-Null
+        foreach ($dir in @($privateDir, $frontendDir)) {
+          if (Test-Path $dir) {
+            Get-ChildItem -Path $dir -Filter "*.pdb" | ForEach-Object {
+              Copy-Item $_.FullName -Destination $pdbDir
+            }
+          }
+        }
+
+    - name: Upload build artifacts
+      uses: actions/upload-artifact@v4
+      if: always()
+      with:
+        name: build-${{ matrix.platform }}-${{ matrix.configuration }}
+        path: package/
+
+  release:
+    needs: build
+    if: github.event_name == 'workflow_dispatch' && inputs.create_release == true
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+    - name: Checkout wined3d_vs
+      uses: actions/checkout@v4
+
+    - name: Download all artifacts
+      uses: actions/download-artifact@v4
+      with:
+        path: artifacts/
+
+    - name: Create release archives
+      run: |
+        cd artifacts
+        for dir in */; do
+          name="${dir%/}"
+          if [ -d "$name" ]; then
+            zip -r "${name}-dlls.zip" "$name" -x "*_pdbs/*"
+            zip -r "${name}-pdbs.zip" "$name" -x "*/*.dll" "*/*.exe"
+          fi
+        done
+        ls -la *.zip
+
+    - name: Create GitHub Release
+      uses: softprops/action-gh-release@v2
+      with:
+        tag_name: "${{ inputs.release_tag || format('build-{0}', github.run_number) }}"
+        name: "${{ inputs.release_tag || format('Build #{0}', github.run_number) }}"
+        body: "Wine D3D DLLs built from ${{ env.WINE_TAG }} with vkd3d ${{ env.VKD3D_TAG }} (Vulkan/d3d12 support). Includes: d3d8, d3d9, d3d11, d3d12, ddraw, dxgi, d3d10core, d2d1, d3dx9_36, d3dxof, d3drm, dsound, wined3d, vkd3d, debug symbols (PDBs)"
+        files: artifacts/*.zip
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -59,20 +59,25 @@ jobs:
         $grammar = "$env:GITHUB_WORKSPACE\vkd3d\include\private\spirv.core.grammar.json"
         $output = "$env:GITHUB_WORKSPACE\vkd3d\include\private\spirv_grammar.h"
         $makeSpirv = "$env:GITHUB_WORKSPACE\vkd3d\libs\vkd3d-shader\make_spirv"
-        if (Test-Path $grammar) {
-          perl $makeSpirv $grammar | Set-Content $output -Encoding utf8
-          Write-Host "Generated spirv_grammar.h"
-        } else {
-          Write-Host "No spirv grammar JSON found, skipping generation"
+        if (-not (Test-Path $grammar)) {
+          Write-Error "spirv.core.grammar.json not found at $grammar"
+          exit 1
         }
+        perl $makeSpirv $grammar | Set-Content $output -Encoding utf8
+        Write-Host "Generated spirv_grammar.h"
 
     - name: Patch vkd3d for MSVC compatibility
       shell: pwsh
       run: |
+        # Patch vkd3d_private.h: MSVC rejects DECLSPEC_ALIGN(sizeof(void *))
         $file = "$env:GITHUB_WORKSPACE\vkd3d\libs\vkd3d\vkd3d_private.h"
         $content = Get-Content $file -Raw
-        $content = $content.Replace(
-          'uint8_t DECLSPEC_ALIGN(sizeof(void *)) descriptors[]',
+        $search = 'uint8_t DECLSPEC_ALIGN(sizeof(void *)) descriptors[]'
+        if (-not $content.Contains($search)) {
+          Write-Error "vkd3d_private.h: expected string not found, patch may be outdated"
+          exit 1
+        }
+        $content = $content.Replace($search,
           @"
         uint8_t
         #ifdef _WIN64
@@ -103,18 +108,30 @@ jobs:
         # without __declspec(dllexport)
         $utilsCFile = "$env:GITHUB_WORKSPACE\vkd3d\libs\vkd3d-utils\vkd3d_utils_main.c"
         $utilsC = Get-Content $utilsCFile -Raw
+        $matchCount = ([regex]::Matches($utilsC, 'VKD3D_UTILS_API ')).Count
+        if ($matchCount -eq 0) {
+          Write-Error "vkd3d_utils_main.c: no VKD3D_UTILS_API found, patch may be outdated"
+          exit 1
+        }
         $utilsC = $utilsC -replace 'VKD3D_UTILS_API ', ''
         Set-Content $utilsCFile $utilsC -NoNewline
-        Write-Host "Patched vkd3d_utils_main.c to remove VKD3D_UTILS_API"
+        Write-Host "Patched vkd3d_utils_main.c: removed $matchCount VKD3D_UTILS_API occurrences"
 
-    - name: Fetch missing wine headers from master
+    - name: Fetch missing wine headers
       shell: pwsh
       run: |
-        # wtypesbase.idl was added to wine after 10.4 release
-        $url = "https://raw.githubusercontent.com/wine-mirror/wine/master/include/wtypesbase.idl"
+        # wtypesbase.idl was added to wine after the tagged release; pin to the same tag
+        $url = "https://raw.githubusercontent.com/wine-mirror/wine/${env:WINE_TAG}/include/wtypesbase.idl"
         $out = "$env:GITHUB_WORKSPACE\wine\include\wtypesbase.idl"
-        Invoke-WebRequest -Uri $url -OutFile $out
-        Write-Host "Downloaded wtypesbase.idl"
+        try {
+          Invoke-WebRequest -Uri $url -OutFile $out
+          Write-Host "Downloaded wtypesbase.idl from $env:WINE_TAG"
+        } catch {
+          # If the file doesn't exist in the tagged release either, try master as fallback
+          $fallbackUrl = "https://raw.githubusercontent.com/wine-mirror/wine/master/include/wtypesbase.idl"
+          Invoke-WebRequest -Uri $fallbackUrl -OutFile $out
+          Write-Warning "wtypesbase.idl not in $env:WINE_TAG, fetched from master"
+        }
 
     - name: Install Vulkan SDK
       uses: humbletim/setup-vulkan-sdk@v1.2.1
@@ -143,15 +160,29 @@ jobs:
         # Set INCLUDE to UCRT+VC only (no Windows SDK um/shared to avoid rpc.h conflicts)
         $env:INCLUDE = "$ucrtPath;$vcPath"
         "INCLUDE=$ucrtPath;$vcPath" | Out-File -Append -Encoding utf8 $env:GITHUB_ENV
-        # Strip $(IncludePath) from all vcxproj files so MSBuild won't add SDK paths via /I flags
+        # Strip $(IncludePath) and $(WindowsSDK_IncludePath) from all vcxproj files
+        # so MSBuild won't add SDK paths via /I flags
         Get-ChildItem "$env:GITHUB_WORKSPACE\wined3d_vs" -Recurse -Filter "*.vcxproj" | ForEach-Object {
           $content = Get-Content $_.FullName -Raw
+          $modified = $false
           if ($content.Contains('$(IncludePath)')) {
             $content = $content.Replace(';$(IncludePath)', '')
+            $modified = $true
+          }
+          if ($content.Contains('$(WindowsSDK_IncludePath)')) {
+            $content = $content.Replace(';$(WindowsSDK_IncludePath)', '')
+            $content = $content.Replace('$(WindowsSDK_IncludePath);', '')
+            $content = $content.Replace('$(WindowsSDK_IncludePath)', '')
+            $modified = $true
+          }
+          if ($modified) {
             Set-Content $_.FullName $content -NoNewline
-            Write-Host "Stripped `$(IncludePath) from $($_.Name)"
+            Write-Host "Stripped SDK include paths from $($_.Name)"
           }
         }
+        # NOTE: wined3d.dll uses /FORCE:MULTIPLE because vkd3d-common.lib
+        # defines D3D12 IIDs that Wine's WIDL-generated headers also define.
+        # The duplicate values are identical (same GUIDs), so this is safe.
 
     - name: Build foundational projects
       shell: pwsh
@@ -208,7 +239,27 @@ jobs:
         /p:Platform=${{ matrix.platform }}
         /verbosity:minimal
       working-directory: wined3d_vs
-      continue-on-error: true
+
+    - name: Verify build outputs
+      shell: pwsh
+      run: |
+        $platform = "${{ matrix.platform }}"
+        $config = "${{ matrix.configuration }}"
+        $privateDir = "$env:GITHUB_WORKSPACE\wined3d_vs\${platform}_${config}"
+        $frontendDir = "$env:GITHUB_WORKSPACE\wined3d_vs\${platform}_${config}_dll"
+        $dlls = @()
+        foreach ($dir in @($privateDir, $frontendDir)) {
+          if (Test-Path $dir) {
+            $dlls += Get-ChildItem -Path $dir -Filter "*.dll"
+          }
+        }
+        $count = $dlls.Count
+        Write-Host "Found $count DLLs"
+        $dlls | ForEach-Object { Write-Host "  $($_.Name)" }
+        if ($count -lt 10) {
+          Write-Error "Expected at least 10 DLLs, got $count. Build may have failed silently."
+          exit 1
+        }
 
     - name: Package DLLs
       shell: pwsh

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -117,21 +117,13 @@ jobs:
         Set-Content $utilsCFile $utilsC -NoNewline
         Write-Host "Patched vkd3d_utils_main.c: removed $matchCount VKD3D_UTILS_API occurrences"
 
-    - name: Fetch missing wine headers
+    - name: Vendor wtypesbase.idl
       shell: pwsh
       run: |
-        # wtypesbase.idl was added to wine after the tagged release; pin to the same tag
-        $url = "https://raw.githubusercontent.com/wine-mirror/wine/${env:WINE_TAG}/include/wtypesbase.idl"
-        $out = "$env:GITHUB_WORKSPACE\wine\include\wtypesbase.idl"
-        try {
-          Invoke-WebRequest -Uri $url -OutFile $out
-          Write-Host "Downloaded wtypesbase.idl from $env:WINE_TAG"
-        } catch {
-          # If the file doesn't exist in the tagged release either, try master as fallback
-          $fallbackUrl = "https://raw.githubusercontent.com/wine-mirror/wine/master/include/wtypesbase.idl"
-          Invoke-WebRequest -Uri $fallbackUrl -OutFile $out
-          Write-Warning "wtypesbase.idl not in $env:WINE_TAG, fetched from master"
-        }
+        # wtypesbase.idl was added to wine after the 10.20 release; vendored in idls/
+        Copy-Item "$env:GITHUB_WORKSPACE\wined3d_vs\idls\wtypesbase.idl" `
+                  "$env:GITHUB_WORKSPACE\wine\include\wtypesbase.idl"
+        Write-Host "Vendored wtypesbase.idl from repo"
 
     - name: Install Vulkan SDK
       uses: humbletim/setup-vulkan-sdk@v1.2.1
@@ -233,12 +225,15 @@ jobs:
         }
 
     - name: Build core solution
+      # Test executables (d3d12_tests, etc.) return non-zero without D3D runtime,
+      # so we tolerate the overall exit code and validate DLLs in the next step.
       run: >
         msbuild wined3d.sln
         /p:Configuration=${{ matrix.configuration }}
         /p:Platform=${{ matrix.platform }}
         /verbosity:minimal
       working-directory: wined3d_vs
+      continue-on-error: true
 
     - name: Verify build outputs
       shell: pwsh

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -339,20 +339,26 @@ jobs:
 
     - name: Determine release tag
       id: tag
+      shell: bash
       run: |
         if [ -n "${{ inputs.release_tag }}" ]; then
-          echo "tag=${{ inputs.release_tag }}" >> "$GITHUB_OUTPUT"
-          echo "name=${{ inputs.release_tag }}" >> "$GITHUB_OUTPUT"
+          raw="${{ inputs.release_tag }}"
         else
-          echo "tag=build-${{ github.run_number }}" >> "$GITHUB_OUTPUT"
-          echo "name=Build #${{ github.run_number }}" >> "$GITHUB_OUTPUT"
+          raw="build-${{ github.run_number }}"
         fi
+        # Git tags cannot contain spaces or most special chars
+        tag=$(echo "$raw" | sed 's/[^a-zA-Z0-9._-]/-/g' | sed 's/--*/-/g' | sed 's/^-\|-$//g')
+        echo "tag=$tag" >> "$GITHUB_OUTPUT"
+        echo "name=$raw" >> "$GITHUB_OUTPUT"
+        echo "Release tag: $tag"
+        echo "Release name: $raw"
 
-    - name: Create git tag
-      run: git tag ${{ steps.tag.outputs.tag }}
-
-    - name: Push tag
-      run: git push origin ${{ steps.tag.outputs.tag }}
+    - name: Create and push git tag
+      shell: bash
+      run: |
+        TAG="${{ steps.tag.outputs.tag }}"
+        git tag "$TAG"
+        git push origin "$TAG"
 
     - name: Create GitHub Release
       uses: softprops/action-gh-release@v2

--- a/d3dx9_36/d3dx9_36.vcxproj
+++ b/d3dx9_36/d3dx9_36.vcxproj
@@ -1259,8 +1259,7 @@
       <AdditionalOptions Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">/wd4244 /wd4018 %(AdditionalOptions)</AdditionalOptions>
       <AdditionalOptions Condition="'$(Configuration)|$(Platform)'=='Release|x64'">/wd4244 /wd4018 %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
-    <ClCompile Include="..\..\wine\dlls\d3dx9_36\txc_compress_dxtn.c" />
-    <ClCompile Include="..\..\wine\dlls\d3dx9_36\txc_fetch_dxtn.c" />
+    <ClCompile Include="..\..\wine\dlls\d3dx9_36\d3dx_helpers.c" />
     <ClCompile Include="..\..\wine\dlls\d3dx9_36\util.c" />
     <ClCompile Include="..\..\wine\dlls\d3dx9_36\volume.c" />
     <ClCompile Include="..\..\wine\dlls\d3dx9_36\xfile.c" />

--- a/d3dx9_36/d3dx9_36.vcxproj.filters
+++ b/d3dx9_36/d3dx9_36.vcxproj.filters
@@ -69,10 +69,7 @@
     <ClCompile Include="..\..\wine\dlls\d3dx9_36\main.c">
       <Filter>Quelldateien</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\wine\dlls\d3dx9_36\txc_compress_dxtn.c">
-      <Filter>Quelldateien</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\wine\dlls\d3dx9_36\txc_fetch_dxtn.c">
+    <ClCompile Include="..\..\wine\dlls\d3dx9_36\d3dx_helpers.c">
       <Filter>Quelldateien</Filter>
     </ClCompile>
   </ItemGroup>

--- a/idls/wtypesbase.idl
+++ b/idls/wtypesbase.idl
@@ -1,0 +1,424 @@
+cpp_quote("/**")
+cpp_quote(" * This file is part of the mingw-w64 runtime package.")
+cpp_quote(" * No warranty is given; refer to the file DISCLAIMER within this package.")
+cpp_quote(" */")
+cpp_quote("")
+
+import "basetsd.h";
+import "guiddef.h";
+
+cpp_quote("")
+[uuid (B1BEA154-1c2f-4da9-9abf-6e2d24eea1be), version (0.1), pointer_default (unique)]
+interface IWinTypesBase {
+cpp_quote("")
+  cpp_quote("#if 0")
+  typedef byte BYTE;
+  typedef unsigned short WORD;
+  typedef unsigned int UINT;
+  typedef int INT;
+  typedef long BOOL;
+  typedef long LONG;
+  typedef unsigned long DWORD;
+  typedef void *HANDLE;
+  typedef WORD *LPWORD;
+  typedef DWORD *LPDWORD;
+  typedef char CHAR;
+  typedef [string] CHAR *LPSTR;
+  typedef [string] const CHAR *LPCSTR;
+  typedef wchar_t WCHAR;
+  typedef WCHAR TCHAR;
+  typedef [string] WCHAR *LPWSTR;
+  typedef [string] TCHAR *LPTSTR;
+  typedef [string] const WCHAR *LPCWSTR;
+  typedef [string] const TCHAR *LPCTSTR;
+  typedef HANDLE *LPHANDLE;
+  cpp_quote("#endif")
+
+cpp_quote("")
+cpp_quote("#if !defined(OLE2ANSI)")
+  typedef WCHAR OLECHAR;
+  typedef [string] OLECHAR *LPOLESTR;
+  typedef [string] const OLECHAR *LPCOLESTR;
+cpp_quote("")
+  cpp_quote("#ifndef __WINESRC__")
+  cpp_quote("#if defined(WINE_UNICODE_NATIVE) || defined(__MINGW32__) || defined(_MSC_VER)")
+  cpp_quote("#define OLESTR(str) L##str")
+  cpp_quote("#else")
+  cpp_quote("#define OLESTR(str) u##str")
+  cpp_quote("#endif")
+  cpp_quote("#endif")
+cpp_quote("#else")
+  cpp_quote("typedef char OLECHAR;")
+  cpp_quote("typedef LPSTR LPOLESTR;")
+  cpp_quote("typedef LPCSTR LPCOLESTR;")
+cpp_quote("")
+  cpp_quote("#define OLESTR(str) str")
+cpp_quote("#endif")
+
+cpp_quote("")
+  cpp_quote("#ifndef _WINDEF_")
+  cpp_quote("#ifndef _MINWINDEF_")
+  typedef void *PVOID, *LPVOID;
+  typedef float FLOAT;
+  cpp_quote("#endif")
+  cpp_quote("#endif")
+
+  cpp_quote("#ifdef _MSC_VER") /* for IDL and MSVC only */
+  typedef double DOUBLE;
+  cpp_quote("#else")
+  cpp_quote("typedef double DECLSPEC_ALIGN(8) DOUBLE;")
+  cpp_quote("#endif")
+
+cpp_quote("")
+  typedef unsigned char UCHAR;
+  typedef short SHORT;
+  typedef unsigned short USHORT;
+  typedef DWORD ULONG;
+  cpp_quote("#ifndef _DWORDLONG_")
+  typedef unsigned __int64 DWORDLONG;
+  typedef DWORDLONG *PDWORDLONG;
+  cpp_quote("#endif")
+
+cpp_quote("")
+  cpp_quote("#ifndef _ULONGLONG_")
+  typedef __int64 LONGLONG;
+  typedef unsigned __int64 ULONGLONG;
+  typedef LONGLONG *PLONGLONG;
+  typedef ULONGLONG *PULONGLONG;
+  cpp_quote("#endif")
+
+  cpp_quote("#if 0")
+  typedef struct _LARGE_INTEGER {
+    LONGLONG QuadPart;
+  } LARGE_INTEGER;
+  typedef LARGE_INTEGER *PLARGE_INTEGER;
+  typedef struct _ULARGE_INTEGER {
+    ULONGLONG QuadPart;
+  } ULARGE_INTEGER;
+  cpp_quote("#endif")
+
+cpp_quote("")
+  cpp_quote("#ifndef _WINBASE_")
+  cpp_quote("#ifndef _FILETIME_")
+  cpp_quote("#define _FILETIME_")
+cpp_quote("")
+  typedef struct _FILETIME {
+    DWORD dwLowDateTime;
+    DWORD dwHighDateTime;
+  } FILETIME,*PFILETIME,*LPFILETIME;
+  cpp_quote("#endif")
+
+cpp_quote("")
+  cpp_quote("#ifndef _SYSTEMTIME_")
+  cpp_quote("#define _SYSTEMTIME_")
+cpp_quote("")
+  typedef struct _SYSTEMTIME {
+    WORD wYear;
+    WORD wMonth;
+    WORD wDayOfWeek;
+    WORD wDay;
+    WORD wHour;
+    WORD wMinute;
+    WORD wSecond;
+    WORD wMilliseconds;
+  } SYSTEMTIME,*PSYSTEMTIME,*LPSYSTEMTIME;
+  cpp_quote("#endif")
+
+cpp_quote("")
+  cpp_quote("#ifndef _SECURITY_ATTRIBUTES_")
+  cpp_quote("#define _SECURITY_ATTRIBUTES_")
+cpp_quote("")
+  typedef struct _SECURITY_ATTRIBUTES {
+    DWORD nLength;
+    LPVOID lpSecurityDescriptor;
+    BOOL bInheritHandle;
+  } SECURITY_ATTRIBUTES,*PSECURITY_ATTRIBUTES,*LPSECURITY_ATTRIBUTES;
+  cpp_quote("#endif")
+
+cpp_quote("")
+  cpp_quote("#ifndef SECURITY_DESCRIPTOR_REVISION")
+  typedef USHORT SECURITY_DESCRIPTOR_CONTROL, *PSECURITY_DESCRIPTOR_CONTROL;
+  typedef PVOID PSID;
+cpp_quote("")
+  typedef struct _ACL {
+    UCHAR AclRevision;
+    UCHAR Sbz1;
+    USHORT AclSize;
+    USHORT AceCount;
+    USHORT Sbz2;
+  } ACL;
+cpp_quote("")
+  typedef ACL *PACL;
+cpp_quote("")
+  typedef struct _SECURITY_DESCRIPTOR {
+    UCHAR Revision;
+    UCHAR Sbz1;
+    SECURITY_DESCRIPTOR_CONTROL Control;
+    PSID Owner;
+    PSID Group;
+    PACL Sacl;
+    PACL Dacl;
+  } SECURITY_DESCRIPTOR,*PISECURITY_DESCRIPTOR;
+  cpp_quote("#endif")
+  cpp_quote("#endif")
+
+cpp_quote("")
+  typedef struct _COAUTHIDENTITY {
+    [size_is (UserLength+1)] USHORT *User;
+    [range (0, 256)]ULONG UserLength;
+    [size_is (DomainLength+1)] USHORT *Domain;
+    [range (0, 256)]ULONG DomainLength;
+    [size_is (PasswordLength+1)] USHORT *Password;
+    [range (0, 256)]ULONG PasswordLength;
+    ULONG Flags;
+  } COAUTHIDENTITY;
+
+cpp_quote("")
+  typedef struct _COAUTHINFO {
+    DWORD dwAuthnSvc;
+    DWORD dwAuthzSvc;
+    LPWSTR pwszServerPrincName;
+    DWORD dwAuthnLevel;
+    DWORD dwImpersonationLevel;
+    COAUTHIDENTITY *pAuthIdentityData;
+    DWORD dwCapabilities;
+  } COAUTHINFO;
+
+cpp_quote("")
+  typedef LONG SCODE;
+  typedef SCODE *PSCODE;
+cpp_quote("")
+  cpp_quote("#ifndef _HRESULT_DEFINED")
+  cpp_quote("#define _HRESULT_DEFINED")
+#if defined (_STRICT_HRESULT)
+  typedef struct _HRESULT_STRUCT {
+    DWORD Data1;
+  } HRESULT_STRUCT,*PHRESULT_STRUCT;
+  typedef PHRESULT_STRUCT HRESULT;
+#else
+  cpp_quote("#ifdef __WIDL__")
+  typedef LONG HRESULT;
+  cpp_quote("#else")
+  cpp_quote("typedef __LONG32 HRESULT;")
+  cpp_quote("#endif")
+#endif
+  cpp_quote("#endif")
+
+  cpp_quote("")
+  cpp_quote("#ifndef __OBJECTID_DEFINED")
+  cpp_quote("#define __OBJECTID_DEFINED")
+  cpp_quote("#define _OBJECTID_DEFINED")
+cpp_quote("")
+  typedef struct _OBJECTID {
+    GUID Lineage;
+    unsigned long Uniquifier;
+  } OBJECTID;
+  cpp_quote("#endif")
+
+cpp_quote("")
+  cpp_quote("#if 0")
+  typedef GUID *REFGUID;
+  typedef IID *REFIID;
+  typedef CLSID *REFCLSID;
+  cpp_quote("#endif")
+
+cpp_quote("")
+  typedef enum tagMEMCTX {
+    MEMCTX_TASK = 1,
+    MEMCTX_SHARED = 2,
+    MEMCTX_MACSYSTEM = 3,
+    MEMCTX_UNKNOWN = -1,
+    MEMCTX_SAME = -2,
+  } MEMCTX;
+  cpp_quote("#ifndef _ROTREGFLAGS_DEFINED")
+  cpp_quote("#define _ROTREGFLAGS_DEFINED")
+cpp_quote("")
+  cpp_quote("#define ROTREGFLAGS_ALLOWANYCLIENT 0x1")
+  cpp_quote("#endif")
+
+cpp_quote("")
+  cpp_quote("#ifndef _APPIDREGFLAGS_DEFINED")
+  cpp_quote("#define _APPIDREGFLAGS_DEFINED")
+cpp_quote("")
+  cpp_quote("#define APPIDREGFLAGS_ACTIVATE_IUSERVER_INDESKTOP 0x1")
+  cpp_quote("#define APPIDREGFLAGS_SECURE_SERVER_PROCESS_SD_AND_BIND 0x2")
+  cpp_quote("#define APPIDREGFLAGS_ISSUE_ACTIVATION_RPC_AT_IDENTIFY 0x4")
+  cpp_quote("#define APPIDREGFLAGS_IUSERVER_UNMODIFIED_LOGON_TOKEN 0x8")
+  cpp_quote("#define APPIDREGFLAGS_IUSERVER_SELF_SID_IN_LAUNCH_PERMISSION 0x10")
+  cpp_quote("#define APPIDREGFLAGS_IUSERVER_ACTIVATE_IN_CLIENT_SESSION_ONLY 0x20")
+  cpp_quote("#define APPIDREGFLAGS_RESERVED1 0x40")
+  cpp_quote("#endif")
+
+cpp_quote("")
+  cpp_quote("#ifndef _DCOMSCM_REMOTECALL_FLAGS_DEFINED")
+  cpp_quote("#define _DCOMSCM_REMOTECALL_FLAGS_DEFINED")
+cpp_quote("")
+  cpp_quote("#define DCOMSCM_ACTIVATION_USE_ALL_AUTHNSERVICES 0x1")
+  cpp_quote("#define DCOMSCM_ACTIVATION_DISALLOW_UNSECURE_CALL 0x2")
+  cpp_quote("#define DCOMSCM_RESOLVE_USE_ALL_AUTHNSERVICES 0x4")
+  cpp_quote("#define DCOMSCM_RESOLVE_DISALLOW_UNSECURE_CALL 0x8")
+  cpp_quote("#define DCOMSCM_PING_USE_MID_AUTHNSERVICE 0x10")
+  cpp_quote("#define DCOMSCM_PING_DISALLOW_UNSECURE_CALL 0x20")
+  cpp_quote("#endif")
+
+cpp_quote("")
+  typedef enum tagCLSCTX {
+    CLSCTX_INPROC_SERVER = 0x01,
+    CLSCTX_INPROC_HANDLER = 0x02,
+    CLSCTX_LOCAL_SERVER = 0x04,
+    CLSCTX_INPROC_SERVER16 = 0x08,
+    CLSCTX_REMOTE_SERVER = 0x10,
+    CLSCTX_INPROC_HANDLER16 = 0x20,
+    CLSCTX_RESERVED1 = 0x40,
+    CLSCTX_RESERVED2 = 0x80,
+    CLSCTX_RESERVED3 = 0x100,
+    CLSCTX_RESERVED4 = 0x200,
+    CLSCTX_NO_CODE_DOWNLOAD = 0x400,
+    CLSCTX_RESERVED5 = 0x800,
+    CLSCTX_NO_CUSTOM_MARSHAL = 0x1000,
+    CLSCTX_ENABLE_CODE_DOWNLOAD = 0x2000,
+    CLSCTX_NO_FAILURE_LOG = 0x4000,
+    CLSCTX_DISABLE_AAA = 0x8000,
+    CLSCTX_ENABLE_AAA = 0x10000,
+    CLSCTX_FROM_DEFAULT_CONTEXT = 0x20000,
+    CLSCTX_ACTIVATE_32_BIT_SERVER = 0x40000,
+    CLSCTX_ACTIVATE_64_BIT_SERVER = 0x80000,
+    CLSCTX_ENABLE_CLOAKING = 0x100000,
+    CLSCTX_APPCONTAINER = 0x400000,
+    CLSCTX_ACTIVATE_AAA_AS_IU = 0x800000,
+    CLSCTX_PS_DLL = (int) 0x80000000,
+  } CLSCTX;
+cpp_quote("")
+  cpp_quote("#define CLSCTX_VALID_MASK (CLSCTX_INPROC_SERVER | CLSCTX_INPROC_HANDLER | CLSCTX_LOCAL_SERVER | CLSCTX_INPROC_SERVER16 | CLSCTX_REMOTE_SERVER | CLSCTX_NO_CODE_DOWNLOAD | CLSCTX_NO_CUSTOM_MARSHAL | CLSCTX_ENABLE_CODE_DOWNLOAD | CLSCTX_NO_FAILURE_LOG | CLSCTX_DISABLE_AAA | CLSCTX_ENABLE_AAA | CLSCTX_FROM_DEFAULT_CONTEXT | CLSCTX_ACTIVATE_32_BIT_SERVER | CLSCTX_ACTIVATE_64_BIT_SERVER | CLSCTX_ENABLE_CLOAKING | CLSCTX_APPCONTAINER | CLSCTX_ACTIVATE_AAA_AS_IU | CLSCTX_PS_DLL)")
+
+cpp_quote("")
+  typedef enum tagMSHLFLAGS {
+    MSHLFLAGS_NORMAL = 0,
+    MSHLFLAGS_TABLESTRONG = 1,
+    MSHLFLAGS_TABLEWEAK = 2,
+    MSHLFLAGS_NOPING = 4,
+    MSHLFLAGS_RESERVED1 = 8,
+    MSHLFLAGS_RESERVED2 = 16,
+    MSHLFLAGS_RESERVED3 = 32,
+    MSHLFLAGS_RESERVED4 = 64
+  } MSHLFLAGS;
+
+cpp_quote("")
+  typedef enum tagMSHCTX {
+    MSHCTX_LOCAL = 0,
+    MSHCTX_NOSHAREDMEM = 1,
+    MSHCTX_DIFFERENTMACHINE = 2,
+    MSHCTX_INPROC = 3,
+    MSHCTX_CROSSCTX = 4
+  } MSHCTX;
+
+cpp_quote("")
+  typedef struct _BYTE_BLOB {
+    unsigned long clSize;
+    [size_is (clSize)] byte abData[];
+  } BYTE_BLOB;
+
+cpp_quote("")
+  typedef [unique] BYTE_BLOB *UP_BYTE_BLOB;
+
+cpp_quote("")
+  typedef struct _WORD_BLOB {
+    unsigned long clSize;
+    [size_is (clSize)] unsigned short asData[];
+  } WORD_BLOB;
+
+cpp_quote("")
+  typedef [unique] WORD_BLOB *UP_WORD_BLOB;
+
+cpp_quote("")
+  typedef struct _DWORD_BLOB {
+    unsigned long clSize;
+    [size_is (clSize)] unsigned long alData[];
+  } DWORD_BLOB;
+
+cpp_quote("")
+  typedef [unique] DWORD_BLOB *UP_DWORD_BLOB;
+
+cpp_quote("")
+  typedef struct _FLAGGED_BYTE_BLOB {
+    unsigned long fFlags;
+    unsigned long clSize;
+    [size_is (clSize)] byte abData[];
+  } FLAGGED_BYTE_BLOB;
+
+cpp_quote("")
+  typedef [unique] FLAGGED_BYTE_BLOB *UP_FLAGGED_BYTE_BLOB;
+
+cpp_quote("")
+  typedef struct _FLAGGED_WORD_BLOB {
+    unsigned long fFlags;
+    unsigned long clSize;
+    [size_is (clSize)] unsigned short asData[];
+  } FLAGGED_WORD_BLOB;
+
+cpp_quote("")
+  typedef [unique] FLAGGED_WORD_BLOB *UP_FLAGGED_WORD_BLOB;
+
+cpp_quote("")
+  typedef struct _BYTE_SIZEDARR {
+    unsigned long clSize;
+    [size_is (clSize)] byte *pData;
+  } BYTE_SIZEDARR;
+
+cpp_quote("")
+  typedef struct _SHORT_SIZEDARR {
+    unsigned long clSize;
+    [size_is (clSize)] unsigned short *pData;
+  } WORD_SIZEDARR;
+
+cpp_quote("")
+  typedef struct _LONG_SIZEDARR {
+    unsigned long clSize;
+    [size_is (clSize)] unsigned long *pData;
+  } DWORD_SIZEDARR;
+
+cpp_quote("")
+  typedef struct _HYPER_SIZEDARR {
+    unsigned long clSize;
+    [size_is (clSize)] hyper *pData;
+  } HYPER_SIZEDARR;
+}
+
+cpp_quote("")
+typedef boolean BOOLEAN;
+cpp_quote("#ifndef _tagBLOB_DEFINED")
+cpp_quote("#define _tagBLOB_DEFINED")
+cpp_quote("#define _BLOB_DEFINED")
+cpp_quote("#define _LPBLOB_DEFINED")
+cpp_quote("")
+typedef struct tagBLOB {
+  ULONG cbSize;
+  [size_is (cbSize)] BYTE *pBlobData;
+} BLOB,*LPBLOB;
+cpp_quote("#endif")
+
+cpp_quote("")
+cpp_quote("#ifndef SID_IDENTIFIER_AUTHORITY_DEFINED")
+cpp_quote("#define SID_IDENTIFIER_AUTHORITY_DEFINED")
+typedef struct _SID_IDENTIFIER_AUTHORITY {
+  UCHAR Value[6];
+} SID_IDENTIFIER_AUTHORITY,*PSID_IDENTIFIER_AUTHORITY;
+cpp_quote("#endif")
+
+cpp_quote("")
+cpp_quote("#ifndef SID_DEFINED")
+cpp_quote("#define SID_DEFINED")
+cpp_quote("")
+typedef struct _SID {
+  BYTE Revision;
+  BYTE SubAuthorityCount;
+  SID_IDENTIFIER_AUTHORITY IdentifierAuthority;
+  [size_is (SubAuthorityCount)] ULONG SubAuthority[*];
+} SID,*PISID;
+
+cpp_quote("")
+typedef struct _SID_AND_ATTRIBUTES {
+  SID *Sid;
+  DWORD Attributes;
+} SID_AND_ATTRIBUTES,*PSID_AND_ATTRIBUTES;
+cpp_quote("#endif")

--- a/vkd3d-idls/vkd3d-idls.vcxproj
+++ b/vkd3d-idls/vkd3d-idls.vcxproj
@@ -101,8 +101,8 @@
       <HeaderFileName>%(Filename).h</HeaderFileName>
     </Midl>
     <CustomBuild>
-      <Command>..\widl\widl.exe -o %(Filename).h --nostdinc %(FullPath) -I..\..\vkd3d\include</Command>
-      <Outputs>%(Filename).h</Outputs>
+      <Command>..\widl\widl.exe -o ..\..\vkd3d\include\%(Filename).h --nostdinc %(FullPath) -I..\..\vkd3d\include</Command>
+      <Outputs>..\..\vkd3d\include\%(Filename).h</Outputs>
     </CustomBuild>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
@@ -121,8 +121,8 @@
       <HeaderFileName>%(Filename).h</HeaderFileName>
     </Midl>
     <CustomBuild>
-      <Command>..\widl\widl.exe -o %(Filename).h --nostdinc %(FullPath) -I..\..\vkd3d\include</Command>
-      <Outputs>%(Filename).h</Outputs>
+      <Command>..\widl\widl.exe -o ..\..\vkd3d\include\%(Filename).h --nostdinc %(FullPath) -I..\..\vkd3d\include</Command>
+      <Outputs>..\..\vkd3d\include\%(Filename).h</Outputs>
     </CustomBuild>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
@@ -145,8 +145,8 @@
       <HeaderFileName>%(Filename).h</HeaderFileName>
     </Midl>
     <CustomBuild>
-      <Command>..\widl\widl.exe -o %(Filename).h --nostdinc %(FullPath) -I..\..\vkd3d\include</Command>
-      <Outputs>%(Filename).h</Outputs>
+      <Command>..\widl\widl.exe -o ..\..\vkd3d\include\%(Filename).h --nostdinc %(FullPath) -I..\..\vkd3d\include</Command>
+      <Outputs>..\..\vkd3d\include\%(Filename).h</Outputs>
     </CustomBuild>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
@@ -169,8 +169,8 @@
       <HeaderFileName>%(Filename).h</HeaderFileName>
     </Midl>
     <CustomBuild>
-      <Command>..\widl\widl.exe -o %(Filename).h --nostdinc %(FullPath) -I..\..\vkd3d\include</Command>
-      <Outputs>%(Filename).h</Outputs>
+      <Command>..\widl\widl.exe -o ..\..\vkd3d\include\%(Filename).h --nostdinc %(FullPath) -I..\..\vkd3d\include</Command>
+      <Outputs>..\..\vkd3d\include\%(Filename).h</Outputs>
     </CustomBuild>
   </ItemDefinitionGroup>
   <ItemGroup>

--- a/vkd3d-shader/vkd3d-shader.vcxproj
+++ b/vkd3d-shader/vkd3d-shader.vcxproj
@@ -100,7 +100,7 @@
       <SDLCheck>true</SDLCheck>
       <ConformanceMode>true</ConformanceMode>
       <DisableSpecificWarnings>4146;4244;4133;4018;4267;4098;4703;%(DisableSpecificWarnings)</DisableSpecificWarnings>
-      <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;HAVE_SPIRV_UNIFIED1_SPIRV_H;LIBVKD3D_SHADER_SOURCE;_USE_MATH_DEFINES;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;HAVE_SPIRV_UNIFIED1_SPIRV_H;HAVE_SPIRV_UNIFIED1_GLSL_STD_450_H;LIBVKD3D_SHADER_SOURCE;_USE_MATH_DEFINES;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -114,7 +114,7 @@
       <SDLCheck>true</SDLCheck>
       <ConformanceMode>true</ConformanceMode>
       <DisableSpecificWarnings>4146;4244;4133;4018;4267;4098;4703;%(DisableSpecificWarnings)</DisableSpecificWarnings>
-      <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;HAVE_SPIRV_UNIFIED1_SPIRV_H;LIBVKD3D_SHADER_SOURCE;_USE_MATH_DEFINES;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;HAVE_SPIRV_UNIFIED1_SPIRV_H;HAVE_SPIRV_UNIFIED1_GLSL_STD_450_H;LIBVKD3D_SHADER_SOURCE;_USE_MATH_DEFINES;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -130,7 +130,7 @@
       <SDLCheck>true</SDLCheck>
       <ConformanceMode>true</ConformanceMode>
       <DisableSpecificWarnings>4146;4244;4133;4018;4267;4098;4703;%(DisableSpecificWarnings)</DisableSpecificWarnings>
-      <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;HAVE_SPIRV_UNIFIED1_SPIRV_H;LIBVKD3D_SHADER_SOURCE;_USE_MATH_DEFINES;NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;HAVE_SPIRV_UNIFIED1_SPIRV_H;HAVE_SPIRV_UNIFIED1_GLSL_STD_450_H;LIBVKD3D_SHADER_SOURCE;_USE_MATH_DEFINES;NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -148,7 +148,7 @@
       <SDLCheck>true</SDLCheck>
       <ConformanceMode>true</ConformanceMode>
       <DisableSpecificWarnings>4146;4244;4133;4018;4267;4098;4703;%(DisableSpecificWarnings)</DisableSpecificWarnings>
-      <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;HAVE_SPIRV_UNIFIED1_SPIRV_H;LIBVKD3D_SHADER_SOURCE;_USE_MATH_DEFINES;NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;HAVE_SPIRV_UNIFIED1_SPIRV_H;HAVE_SPIRV_UNIFIED1_GLSL_STD_450_H;LIBVKD3D_SHADER_SOURCE;_USE_MATH_DEFINES;NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>

--- a/vkd3d-utils/vkd3d-utils.vcxproj
+++ b/vkd3d-utils/vkd3d-utils.vcxproj
@@ -70,22 +70,22 @@
   </ImportGroup>
   <PropertyGroup Label="UserMacros" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
-    <IncludePath>$(VULKAN_SDK)\Include;..\..\vkd3d\include;..\..\vkd3d\include\private;..\vkd3d-idls;..\vkd3d;..\wined3d;$(VC_IncludePath);$(WindowsSDK_IncludePath)</IncludePath>
+    <IncludePath>$(VULKAN_SDK)\Include;..\..\vkd3d\include;..\..\vkd3d\include\private;..\vkd3d;..\wined3d;$(VC_IncludePath);$(WindowsSDK_IncludePath)</IncludePath>
     <IntDir>$(Platform)_$(Configuration)\</IntDir>
     <OutDir>$(SolutionDir)$(Platform)_$(Configuration)\</OutDir>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
-    <IncludePath>$(VULKAN_SDK)\Include;..\..\vkd3d\include;..\..\vkd3d\include\private;..\vkd3d-idls;..\vkd3d;..\wined3d;$(VC_IncludePath);$(WindowsSDK_IncludePath)</IncludePath>
+    <IncludePath>$(VULKAN_SDK)\Include;..\..\vkd3d\include;..\..\vkd3d\include\private;..\vkd3d;..\wined3d;$(VC_IncludePath);$(WindowsSDK_IncludePath)</IncludePath>
     <IntDir>$(Platform)_$(Configuration)\</IntDir>
     <OutDir>$(SolutionDir)$(Platform)_$(Configuration)\</OutDir>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
-    <IncludePath>$(VULKAN_SDK)\Include;..\..\vkd3d\include;..\..\vkd3d\include\private;..\vkd3d-idls;..\vkd3d;..\wined3d;$(VC_IncludePath);$(WindowsSDK_IncludePath)</IncludePath>
+    <IncludePath>$(VULKAN_SDK)\Include;..\..\vkd3d\include;..\..\vkd3d\include\private;..\vkd3d;..\wined3d;$(VC_IncludePath);$(WindowsSDK_IncludePath)</IncludePath>
     <IntDir>$(Platform)_$(Configuration)\</IntDir>
     <OutDir>$(SolutionDir)$(Platform)_$(Configuration)\</OutDir>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
-    <IncludePath>$(VULKAN_SDK)\Include;..\..\vkd3d\include;..\..\vkd3d\include\private;..\vkd3d-idls;..\vkd3d;..\wined3d;$(VC_IncludePath);$(WindowsSDK_IncludePath)</IncludePath>
+    <IncludePath>$(VULKAN_SDK)\Include;..\..\vkd3d\include;..\..\vkd3d\include\private;..\vkd3d;..\wined3d;$(VC_IncludePath);$(WindowsSDK_IncludePath)</IncludePath>
     <IntDir>$(Platform)_$(Configuration)\</IntDir>
     <OutDir>$(SolutionDir)$(Platform)_$(Configuration)\</OutDir>
   </PropertyGroup>
@@ -95,7 +95,8 @@
       <Optimization>Disabled</Optimization>
       <SDLCheck>true</SDLCheck>
       <ConformanceMode>true</ConformanceMode>
-      <PreprocessorDefinitions>_WINDLL;__C89_NAMELESS=;LIBVKD3D_UTILS_SOURCE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_WINDLL;__C89_NAMELESS=;LIBVKD3D_UTILS_SOURCE;_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <DisableSpecificWarnings>4146;4996;4133;4244;4267;4018;4312;%(DisableSpecificWarnings)</DisableSpecificWarnings>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -107,7 +108,8 @@
       <Optimization>Disabled</Optimization>
       <SDLCheck>true</SDLCheck>
       <ConformanceMode>true</ConformanceMode>
-      <PreprocessorDefinitions>_WINDLL;__C89_NAMELESS=;LIBVKD3D_UTILS_SOURCE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_WINDLL;__C89_NAMELESS=;LIBVKD3D_UTILS_SOURCE;_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <DisableSpecificWarnings>4146;4996;4133;4244;4267;4018;4312;%(DisableSpecificWarnings)</DisableSpecificWarnings>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -121,7 +123,8 @@
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <SDLCheck>true</SDLCheck>
       <ConformanceMode>true</ConformanceMode>
-      <PreprocessorDefinitions>_WINDLL;__C89_NAMELESS=;LIBVKD3D_UTILS_SOURCE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_WINDLL;__C89_NAMELESS=;LIBVKD3D_UTILS_SOURCE;_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <DisableSpecificWarnings>4146;4996;4133;4244;4267;4018;4312;%(DisableSpecificWarnings)</DisableSpecificWarnings>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -137,7 +140,8 @@
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <SDLCheck>true</SDLCheck>
       <ConformanceMode>true</ConformanceMode>
-      <PreprocessorDefinitions>_WINDLL;__C89_NAMELESS=;LIBVKD3D_UTILS_SOURCE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_WINDLL;__C89_NAMELESS=;LIBVKD3D_UTILS_SOURCE;_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <DisableSpecificWarnings>4146;4996;4133;4244;4267;4018;4312;%(DisableSpecificWarnings)</DisableSpecificWarnings>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>

--- a/winecrt0/winecrt0.vcxproj
+++ b/winecrt0/winecrt0.vcxproj
@@ -172,11 +172,11 @@
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>
-    <ClCompile Include="..\..\wine\libs\winecrt0\debug.c" />
-    <ClCompile Include="..\..\wine\libs\winecrt0\dll_canunload.c" />
-    <ClCompile Include="..\..\wine\libs\winecrt0\dll_main.c" />
-    <ClCompile Include="..\..\wine\libs\winecrt0\dll_register.c" />
-    <ClCompile Include="..\..\wine\libs\winecrt0\register.c" />
+    <ClCompile Include="..\..\wine\dlls\winecrt0\debug.c" />
+    <ClCompile Include="..\..\wine\dlls\winecrt0\dll_canunload.c" />
+    <ClCompile Include="..\..\wine\dlls\winecrt0\dll_main.c" />
+    <ClCompile Include="..\..\wine\dlls\winecrt0\dll_register.c" />
+    <ClCompile Include="..\..\wine\dlls\winecrt0\register.c" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\wine\dlls\winecrt0\crt0_private.h" />

--- a/wined3d/wined3d.vcxproj
+++ b/wined3d/wined3d.vcxproj
@@ -106,9 +106,9 @@
     <Link>
       <SubSystem>Windows</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <AdditionalDependencies>winecrt0.lib;gdi32.lib;user32.lib;advapi32.lib;opengl32.lib;ntdll.lib;vkd3d.lib;vkd3d-shader.lib</AdditionalDependencies>
+      <AdditionalDependencies>winecrt0.lib;gdi32.lib;user32.lib;advapi32.lib;opengl32.lib;ntdll.lib;vkd3d.lib;vkd3d-shader.lib;vkd3d-utils.lib;vkd3d-common.lib</AdditionalDependencies>
       <AdditionalLibraryDirectories>..\Debug;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
-      <AdditionalOptions>/IGNORE:4093</AdditionalOptions>
+      <AdditionalOptions>/IGNORE:4093 /FORCE:MULTIPLE</AdditionalOptions>
       <ModuleDefinitionFile>$(IntDir)$(TargetName).def</ModuleDefinitionFile>
     </Link>
     <Midl>
@@ -126,9 +126,9 @@
     <Link>
       <SubSystem>Windows</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <AdditionalDependencies>winecrt0.lib;gdi32.lib;user32.lib;advapi32.lib;opengl32.lib;ntdll.lib;vkd3d.lib;vkd3d-shader.lib</AdditionalDependencies>
+      <AdditionalDependencies>winecrt0.lib;gdi32.lib;user32.lib;advapi32.lib;opengl32.lib;ntdll.lib;vkd3d.lib;vkd3d-shader.lib;vkd3d-utils.lib;vkd3d-common.lib</AdditionalDependencies>
       <AdditionalLibraryDirectories>..\Debug;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
-      <AdditionalOptions>/IGNORE:4093</AdditionalOptions>
+      <AdditionalOptions>/IGNORE:4093 /FORCE:MULTIPLE</AdditionalOptions>
       <ModuleDefinitionFile>$(IntDir)$(TargetName).def</ModuleDefinitionFile>
     </Link>
     <Midl>
@@ -150,9 +150,9 @@
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
-      <AdditionalDependencies>winecrt0.lib;gdi32.lib;user32.lib;advapi32.lib;opengl32.lib;ntdll.lib;vkd3d.lib;vkd3d-shader.lib</AdditionalDependencies>
+      <AdditionalDependencies>winecrt0.lib;gdi32.lib;user32.lib;advapi32.lib;opengl32.lib;ntdll.lib;vkd3d.lib;vkd3d-shader.lib;vkd3d-utils.lib;vkd3d-common.lib</AdditionalDependencies>
       <AdditionalLibraryDirectories>..\Debug;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
-      <AdditionalOptions>/IGNORE:4093</AdditionalOptions>
+      <AdditionalOptions>/IGNORE:4093 /FORCE:MULTIPLE</AdditionalOptions>
       <ModuleDefinitionFile>$(IntDir)$(TargetName).def</ModuleDefinitionFile>
     </Link>
     <Midl>
@@ -174,9 +174,9 @@
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
-      <AdditionalDependencies>winecrt0.lib;gdi32.lib;user32.lib;advapi32.lib;opengl32.lib;ntdll.lib;vkd3d.lib;vkd3d-shader.lib</AdditionalDependencies>
+      <AdditionalDependencies>winecrt0.lib;gdi32.lib;user32.lib;advapi32.lib;opengl32.lib;ntdll.lib;vkd3d.lib;vkd3d-shader.lib;vkd3d-utils.lib;vkd3d-common.lib</AdditionalDependencies>
       <AdditionalLibraryDirectories>..\Debug;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
-      <AdditionalOptions>/IGNORE:4093</AdditionalOptions>
+      <AdditionalOptions>/IGNORE:4093 /FORCE:MULTIPLE</AdditionalOptions>
       <ModuleDefinitionFile>$(IntDir)$(TargetName).def</ModuleDefinitionFile>
     </Link>
     <Midl>


### PR DESCRIPTION
- Add GitHub Actions CI workflow building all D3D DLLs
- Update Wine from 10.4 to 10.20, vkd3d from 1.14 to 1.19
- Exclude Windows SDK headers to avoid rpc.h/rpcndr.h conflicts
- Patch vkd3d_utils.h and vkd3d_utils_main.c to resolve linkage conflicts
- Generate spirv_grammar.h for vkd3d-1.19 at CI time
- Fix vkd3d-idls output path for WIDL-generated headers
- Link vkd3d-common.lib and vkd3d-utils.lib in wined3d
- Update d3dx9_36 source files for wine-10.20
- Builds 15 DLLs: wined3d, d3d8, d3d9, ddraw, dxgi, d3d10core, d3d11, d3d12, d2d1, d3drm, d3dx9_36, d3dxof, dsound, vkd3d, vkd3d-shader